### PR TITLE
Fill in compat entries for every dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,14 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 
 [compat]
+Combinatorics = "1"
+Distances = "0.9,0.10"
+NearestNeighbors = "0.4"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test","Random"]
+test = ["Test", "Random"]


### PR DESCRIPTION
For some reason when I add ScatteredInterpolation.jl to my project it downgrades some other packages and insists on using an older version of Distances.jl. This doesn't happen when all of the dependencies are specified in the compat section of Project.toml (which is preferred practice anyways).

I've included Distances `v0.9` because it's only been `v0.10` since late 2020. Combinatorics has also been `v1` since 2019 and NearestNeighbors has been on `v0.4` for even longer.